### PR TITLE
Signed SizeInt to unsigned size_t + typo fix

### DIFF
--- a/src/webui.pas
+++ b/src/webui.pas
@@ -42,69 +42,69 @@ type
 
 // -- Structs -------------------------
   webui_event_t = record
-    window: SizeInt; // The window object number
-    event_type: SizeInt; // Event type
+    window: size_t; // The window object number
+    event_type: size_t; // Event type
     element: PChar; // HTML element ID
     data: PChar; // JavaScript data
     size: Int64; // JavaScript data len
-    event_number: SizeInt; // Internal WebUI
+    event_number: size_t; // Internal WebUI
   end;
 
   Pwebui_event_t = ^webui_event_t;
 
   TWebuiEventProc = procedure(e: Pwebui_event_t);
-  TWebuiInterfaceEventProc = procedure(window, event_type: SizeInt; element, data: PChar; data_size: Int64; event_number: SizeInt);
+  TWebuiInterfaceEventProc = procedure(window, event_type: size_t; element, data: PChar; data_size: Int64; event_number: size_t);
 
 // -- Definitions ---------------------
 // Create a new webui window object.
-function webui_new_window: SizeInt; stdcall; external webuilib;
+function webui_new_window: size_t; stdcall; external webuilib;
 // Create a new webui window object.
-procedure webui_new_window_id(window_number: SizeInt); stdcall; external webuilib;
+procedure webui_new_window_id(window_number: size_t); stdcall; external webuilib;
 // Get a free window ID that can be used with `webui_new_window_id()`
-function webui_get_new_window_id: SizeInt; stdcall; external webuilib;
+function webui_get_new_window_id: size_t; stdcall; external webuilib;
 // Bind a specific html element click event with a function. Empty element means all events.
-function webui_bind(window: SizeInt; const element: PChar; func: TWebuiEventProc): SizeInt; stdcall; external webuilib;
+function webui_bind(window: size_t; const element: PChar; func: TWebuiEventProc): size_t; stdcall; external webuilib;
 // Show a window using a embedded HTML, or a file. If the window is already opened then it will be refreshed.
-function webui_show(window: SizeInt; const content: PChar): Boolean; stdcall; external webuilib;
+function webui_show(window: size_t; const content: PChar): Boolean; stdcall; external webuilib;
 // Same as webui_show(). But with a specific web browser.
-function webui_show_browser(window: SizeInt; const content: PChar; browser: SizeInt): Boolean; stdcall; external webuilib;
+function webui_show_browser(window: size_t; const content: PChar; browser: size_t): Boolean; stdcall; external webuilib;
 // Set the window in Kiosk mode (Full screen)
-procedure webui_set_kiosk(window: SizeInt; status: Boolean); stdcall; external webuilib;
+procedure webui_set_kiosk(window: size_t; status: Boolean); stdcall; external webuilib;
 // Wait until all opened windows get closed.
 procedure webui_wait; stdcall; external webuilib;
 // Close a specific window only. The window object will still exist.
-procedure webui_close(window: SizeInt); stdcall; external webuilib;
+procedure webui_close(window: size_t); stdcall; external webuilib;
 // Close a specific window and free all memory resources.
-procedure webui_destroy(window: SizeInt); stdcall; external webuilib;
+procedure webui_destroy(window: size_t); stdcall; external webuilib;
 // Close all opened windows. webui_wait() will break.
 procedure webui_exit; stdcall; external webuilib;
 // Set the web-server root folder path.
-function webui_set_root_folder(window: SizeInt; const path: PChar): Boolean; stdcall; external webuilib;
+function webui_set_root_folder(window: size_t; const path: PChar): Boolean; stdcall; external webuilib;
 // Set the web-server root folder path for all windows. Should be used before `webui_show()`.
 function webui_set_default_root_folder(const path: PChar): Boolean; stdcall; external external webuilib; 
 // Set a custom handler to serve files
-procedure webui_set_file_handler(window: SizeInt; handler: Pointer); stdcall; external webuilib;
+procedure webui_set_file_handler(window: size_t; handler: Pointer); stdcall; external webuilib;
 
 // -- Other ---------------------------
 // Check a specific window if it's still running
-function webui_is_shown(window: SizeInt): Boolean; stdcall; external webuilib;
+function webui_is_shown(window: size_t): Boolean; stdcall; external webuilib;
 // Set the maximum time in seconds to wait for the browser to start
-procedure webui_set_timeout(second: SizeInt); stdcall; external webuilib;
+procedure webui_set_timeout(second: size_t); stdcall; external webuilib;
 // Set the default embedded HTML favicon
-procedure webui_set_icon(window: SizeInt; const icon, icon_type: PChar); stdcall; external webuilib;
+procedure webui_set_icon(window: size_t; const icon, icon_type: PChar); stdcall; external webuilib;
 // Allow the window URL to be re-used in normal web browsers
-procedure webui_set_multi_access(window: SizeInt; status: Boolean); stdcall; external webuilib;
+procedure webui_set_multi_access(window: size_t; status: Boolean); stdcall; external webuilib;
 // Get process id (The web browser may create another process for the window)
-function webui_get_child_process_id(window: SizeInt): SizeInt; stdcall; external webuilib;
-function webui_get_parent_process_id(window: SizeInt): SizeInt; stdcall; external webuilib;
+function webui_get_child_process_id(window: size_t): size_t; stdcall; external webuilib;
+function webui_get_parent_process_id(window: size_t): size_t; stdcall; external webuilib;
 
 // -- JavaScript ----------------------
 // Run JavaScript quickly with no waiting for the response.
-procedure webui_run(window: SizeInt; const script: PChar); stdcall; external webuilib;
+procedure webui_run(window: size_t; const script: PChar); stdcall; external webuilib;
 // Run a JavaScript, and get the response back (Make sure your local buffer can hold the response).
-function webui_script(window: SizeInt; const script: PChar; timeout: SizeInt; buffer: PChar; buffer_length: SizeInt): Boolean; stdcall; external webuilib;
+function webui_script(window: size_t; const script: PChar; timeout: size_t; buffer: PChar; buffer_length: size_t): Boolean; stdcall; external webuilib;
 // Chose between Deno and Nodejs runtime for .js and .ts files.
-procedure webui_set_runtime(window: SizeInt; runtime: SizeInt); stdcall; external webuilib;
+procedure webui_set_runtime(window: size_t; runtime: size_t); stdcall; external webuilib;
 // Parse argument as integer.
 function webui_get_int(e: Pwebui_event_t): Int64; stdcall; external webuilib;
 // Parse argument as string.
@@ -124,27 +124,27 @@ function webui_decode(const str: PChar): PChar; stdcall; external webuilib;
 // Safely free a buffer allocated by WebUI, for example when using webui_encode().
 procedure webui_free(ptr: Pointer); stdcall; external webuilib;
 // Safely allocate memory using the WebUI memory management system.
-function webui_malloc(size: SizeInt): Pointer; stdcall; external webuilib;
+function webui_malloc(size: size_t): Pointer; stdcall; external webuilib;
 // Safely send raw data to the UI.
-procedure webui_send_raw(window: SizeInt; const func: PChar; raw: Pointer; size: SizeInt); stdcall; external webuilib;
+procedure webui_send_raw(window: size_t; const func: PChar; raw: Pointer; size: size_t); stdcall; external webuilib;
 // Run the window in hidden mode.
-procedure webui_set_hide(window: SizeInt; status: Boolean); stdcall; external webuilib;
+procedure webui_set_hide(window: size_t; status: Boolean); stdcall; external webuilib;
 // Set the window size.
-procedure webui_set_size(window: SizeInt; width, height: UInt32); stdcall; external webuilib;
+procedure webui_set_size(window: size_t; width, height: UInt32); stdcall; external webuilib;
 // Set the window position.
-procedure webui_set_position(window: SizeInt; x, y: UInt32); stdcall; external webuilib;
+procedure webui_set_position(window: size_t; x, y: UInt32); stdcall; external webuilib;
 
 // -- Interface -----------------------
 // Bind a specific html element click event with a function. Empty element means all events.
-function webui_interface_bind(window: SizeInt; const element: PChar; func: TWebuiInterfaceEventProc): SizeInt; stdcall; external webuilib;
+function webui_interface_bind(window: size_t; const element: PChar; func: TWebuiInterfaceEventProc): size_t; stdcall; external webuilib;
 // When using `webui_interface_bind()` you may need this function to easily set your callback response.
-procedure webui_interface_set_response(window, event_number: SizeInt; const response: PChar); stdcall; external webuilib;
+procedure webui_interface_set_response(window, event_number: size_t; const response: PChar); stdcall; external webuilib;
 // Check if the app is still running or not.
 function webui_interface_is_app_running: Boolean; stdcall; external webuilib;
 // Get window unique ID
-function webui_interface_get_window_id(window: SizeInt): SizeInt; stdcall; external webuilib;
+function webui_interface_get_window_id(window: size_t): size_t; stdcall; external webuilib;
 // Get a unique ID. Same ID as `webui_bind()`. Return > 0 if bind exists.
-function webui_interface_get_bind_id(window: SizeInt; const element: PChar): SizeInt; stdcall; external webuilib;
+function webui_interface_get_bind_id(window: size_t; const element: PChar): size_t; stdcall; external webuilib;
 
 
 implementation

--- a/src/webui.pas
+++ b/src/webui.pas
@@ -81,7 +81,7 @@ procedure webui_exit; stdcall; external webuilib;
 // Set the web-server root folder path.
 function webui_set_root_folder(window: size_t; const path: PChar): Boolean; stdcall; external webuilib;
 // Set the web-server root folder path for all windows. Should be used before `webui_show()`.
-function webui_set_default_root_folder(const path: PChar): Boolean; stdcall; external external webuilib; 
+function webui_set_default_root_folder(const path: PChar): Boolean; stdcall; external webuilib; 
 // Set a custom handler to serve files
 procedure webui_set_file_handler(window: size_t; handler: Pointer); stdcall; external webuilib;
 


### PR DESCRIPTION
In "webui_set_default_root_folder" there is a typo "stdcall; external external webuilib;", double "external".

SizeInt should be changed to size_t because of signed/unsigned difference, C version has unsigned size_t.